### PR TITLE
Explicitly define a subsecond timestamp

### DIFF
--- a/rsyslog.conf
+++ b/rsyslog.conf
@@ -28,7 +28,8 @@ input(type="imudp" port="514")
 # Use traditional timestamp format.
 # To enable high precision timestamps, comment out the following line.
 #
-#$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
+$ActionFileDefaultTemplate precise
+$template precise,"%timegenerated:1:10:date-rfc3339% %timegenerated:12:23:date-rfc3339% %HOSTNAME% %syslogtag%%msg:::drop-last-lf%\n"
 
 #
 # Set the default permissions for all log files.


### PR DESCRIPTION
Taken from https://github.com/Graylog2/graylog2-server/issues/467